### PR TITLE
Survival HUD toggle

### DIFF
--- a/src/HUDIndicatorManager.h
+++ b/src/HUDIndicatorManager.h
@@ -8,19 +8,18 @@ class HUDIndicatorManager
 public:
 	inline static void Install()
 	{
-		/*
-		REL::Relocation<std::uintptr_t> HUDWidget_Hook{ TweenMenu_Sub_offset, 0x7B };
+		REL::Relocation<std::uintptr_t> HUDIndicator_Hook{ HUDMenu_Update_offset, 0xD5D };
 
 		auto& trampoline = SKSE::GetTrampoline();
-		trampoline.write_call<5>(HUDWidget_Hook.address(), IsHUDIndicatorEnabled);
-
-		logger::info("Installed hook for HUD Indicator."sv);
-		*/
+		_CheckSurvivalHUD = trampoline.write_call<5>(HUDIndicator_Hook.address(), CheckSurvivalHUD);
 	}
 
 private:
-	inline static bool IsHUDIndicatorEnabled()
+	inline static int32_t CheckSurvivalHUD(void* menu, bool survivalModeToggle)
 	{
-		return Survival::FeatureIsEnabled(Survival::Feature::HUDIndicators);
+		bool isEnabled = Survival::FeatureIsEnabled(Survival::Feature::HUDIndicators);
+		return _CheckSurvivalHUD(menu, isEnabled);
 	}
+
+	inline static REL::Relocation<decltype(CheckSurvivalHUD)> _CheckSurvivalHUD;
 };

--- a/src/Offsets.h
+++ b/src/Offsets.h
@@ -10,6 +10,7 @@ constexpr REL::ID StatsMenu_Sub_offset{ 51638 };	//Stats menu when sleeping
 constexpr REL::ID Inventory_offset{ 51019 };
 constexpr REL::ID OnEquipped_StatsUpdate_offset{ 51473 };
 constexpr REL::ID UIDescription_offset{ 51023 };
+constexpr REL::ID HUDMenu_Update_offset{ 50718 };
 
 constexpr REL::ID SurvWarmthSettings_Normal_offset{ 502630 };
 constexpr REL::ID SurvWarmthSettings_Warm_offset{ 502631 };


### PR DESCRIPTION
Resolves #12.

I was trying out a different hook as well, at `0x140887140+10`, but for some reason when I used that, I could never get the HUD back after disabling it. This one seems to work correctly, but it takes a few seconds for the scripts to update the variables before it takes effect.