### PR TITLE
Update/1.6.629 compatibility

### DIFF
--- a/include/WarmthManager.h
+++ b/include/WarmthManager.h
@@ -79,7 +79,6 @@ private:
 					constexpr RE::FormID FrostfallWarmthGood{ 0x01CC0E12 };
 					constexpr RE::FormID FrostfallWarmthExcellent{ 0x01CC0E13 };
 					constexpr RE::FormID FrostfallWarmthMax{ 0x01CC0E14 };
-					constexpr RE::FormID FrostfallIsCloakFur{ 0x01CC0E1E };
 
 					switch (keyword->formID) {
 					case FrostfallWarmthPoor:


### PR DESCRIPTION
Unused keyword was being treated as a build error.
I decided to remove it, as it didn't seem to be referenced anywhere. If this is incorrect I can adjust.
